### PR TITLE
Fix regex - prohibit whitespaces in footnotes

### DIFF
--- a/src/tidyFootnotes.ts
+++ b/src/tidyFootnotes.ts
@@ -1,7 +1,7 @@
 import { Editor } from 'obsidian';
 
-const reKey = /\[\^(.+?(?=\]))\]/gi;
-const reDefinition = /\[\^(.+)\]\:/;
+const reKey = /\[\^([^\s]+?(?=\]))\]/gi;
+const reDefinition = /\[\^([^\s]+)\]:/;
 
 /** An existing footnote key or definition. */
 interface Marker {


### PR DESCRIPTION
I had the problem that a footnote definition was recognized even though it wasn't one and therefore the entire algorithm no longer worked.

Example text:
```
The GHG Protocol[^1] is an internationally recognized standard for measuring and reporting greenhouse gas emissions, for entire companies or just for individual products. The emissions are divided into three scopes [[@WorldResourcesInstitute.2011.GHGScopeStandard]]:
```

The regex should only match the 1, but it matched everything until the colon:
```
1] is an internationally recognized standard for measuring and reporting greenhouse gas emissions, for entire companies or just for individual products. The emissions are divided into three scopes [[@WorldResourcesInstitute.2011.GHGScopeStandard]
```

This PR fixes that by allowing only footnote characters that are not whitespace.